### PR TITLE
Fix hardcoded Model status to reflect runtime state

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -223,8 +223,8 @@ function App() {
       <section className="status-grid">
         <div className="status-card">
           <p className="label">Model</p>
-          <p className="value">Ready</p>
-          <span className="pill">Loaded</span>
+          <p className="value">{status.ready ? "Ready" : "Not Ready"}</p>
+          <span className={status.ready ? "pill" : "pill muted"}>{status.ready ? "Loaded" : "Unavailable"}</span>
         </div>
         <div className="status-card">
           <p className="label">Backend</p>


### PR DESCRIPTION
## Summary
- The Model status card in the UI always showed "Ready"/"Loaded" regardless of actual backend state (e.g., after a crash or CUDA error)
- Now derives the Model card display from the health check `status.ready` field, showing "Not Ready"/"Unavailable" when the model is down
- Minimal change — uses existing health status data that was already being tracked

## Test plan
- [ ] Verify the Model card shows "Ready"/"Loaded" when backend is healthy
- [ ] Kill the backend process and verify the card updates to "Not Ready"/"Unavailable"
- [ ] Restart the backend and confirm it returns to "Ready"/"Loaded"

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)