### PR TITLE
Make paste timing configurable and convert to async/await

### DIFF
--- a/apps/desktop/electron/clipboard.ts
+++ b/apps/desktop/electron/clipboard.ts
@@ -25,20 +25,29 @@ export const setClipboardText = (text: string): void => {
 
 export const getClipboardText = (): string => clipboard.readText();
 
-export const sendPaste = (): void => {
-  // Small delay to ensure clipboard is ready and focus is restored
-  setTimeout(() => {
-    // Simulate Ctrl+V keystroke
-    uIOhook.keyTap(UiohookKey.V, [UiohookKey.Ctrl]);
-    // Restore previous clipboard content after paste
-    setTimeout(() => {
-      if (previousClipboardText !== null) {
-        clipboard.writeText(previousClipboardText);
-        previousClipboardText = null;
-      } else {
-        clipboard.clear();
-      }
-    }, 100);
-  }, 50);
+export type PasteTimingOptions = {
+  focusDelayMs?: number;
+  restoreDelayMs?: number;
+};
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const sendPaste = async (options: PasteTimingOptions = {}): Promise<void> => {
+  const { focusDelayMs = 50, restoreDelayMs = 100 } = options;
+
+  // Wait for clipboard to be ready and focus to be restored
+  await delay(focusDelayMs);
+
+  // Simulate Ctrl+V keystroke
+  uIOhook.keyTap(UiohookKey.V, [UiohookKey.Ctrl]);
+
+  // Restore previous clipboard content after paste
+  await delay(restoreDelayMs);
+  if (previousClipboardText !== null) {
+    clipboard.writeText(previousClipboardText);
+    previousClipboardText = null;
+  } else {
+    clipboard.clear();
+  }
 };
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -391,7 +391,7 @@ const startDictation = async () => {
         addTranscript(sanitized);
         sendToMain("dictation:final", { text: sanitized });
         setClipboardText(sanitized);
-        sendPaste();
+        sendPaste(settings.paste);
         showOverlay(`Inserted: ${sanitized.slice(0, 30)}`, "inserted");
       }
       if (event.error) {

--- a/apps/desktop/electron/settings.ts
+++ b/apps/desktop/electron/settings.ts
@@ -41,11 +41,17 @@ export type OverlaySettings = {
   autoHideMs: number;
 };
 
+export type PasteSettings = {
+  focusDelayMs: number;
+  restoreDelayMs: number;
+};
+
 export type AppSettings = {
   hotkey: HotkeySettings;
   audio: AudioSettings;
   backend: BackendSettings;
   overlay: OverlaySettings;
+  paste: PasteSettings;
   startMinimized: boolean;
   showNotifications: boolean;
 };
@@ -76,6 +82,10 @@ const DEFAULT_SETTINGS: AppSettings = {
     yOffset: 20,
     autoHideMs: 2000,
   },
+  paste: {
+    focusDelayMs: 50,
+    restoreDelayMs: 100,
+  },
   startMinimized: true,
   showNotifications: true,
 };
@@ -99,6 +109,7 @@ export const loadSettings = (): AppSettings => {
       audio: { ...DEFAULT_SETTINGS.audio, ...parsed.audio },
       backend: { ...DEFAULT_SETTINGS.backend, ...parsed.backend },
       overlay: { ...DEFAULT_SETTINGS.overlay, ...parsed.overlay },
+      paste: { ...DEFAULT_SETTINGS.paste, ...parsed.paste },
     };
   } catch (error) {
     console.warn("Failed to load settings, using defaults", error);


### PR DESCRIPTION
## Summary
- Replaced hardcoded 50ms/100ms `setTimeout` delays in `sendPaste()` with configurable `focusDelayMs` and `restoreDelayMs` settings
- Converted nested setTimeout callbacks to async/await for clearer control flow
- Added `PasteSettings` type and defaults (50ms/100ms — same as before, but now tunable)
- Users on slow systems or remote desktop can increase the delays to avoid missed pastes

## Test plan
- [ ] Verify default paste behavior is unchanged (50ms focus, 100ms restore)
- [ ] Increase delays in settings and verify paste still works on slow apps (e.g., Word)
- [ ] Verify clipboard is restored to previous content after paste
- [ ] Verify settings persist across app restarts

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)