### PR TITLE
Add backend orphan process cleanup on startup

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -18,7 +18,7 @@ import {
   getPythonInfoForExecutable,
   resolveVenvPython,
 } from "./python-finder";
-import { startBackend } from "./backend";
+import { cleanupOrphanedBackend, startBackend } from "./backend";
 import {
   APP_ROOT,
   BACKEND_ROOT,
@@ -290,6 +290,8 @@ const ensureBackend = async () => {
 };
 
 const startBackendProcess = async () => {
+  cleanupOrphanedBackend();
+
   const [nativeDepsResult, pythonResult] = await Promise.allSettled([
     ensureNativeAudioDeps((line) => {
       sendToMain("backend:log", line);


### PR DESCRIPTION
## Summary
- Writes a `backend.pid` file when the Python backend starts, removes it on normal exit
- On app launch, checks for a stale PID file from a previous non-graceful exit and kills the orphaned process
- Prevents GPU-consuming Python processes from running indefinitely after Electron crashes or is force-killed

## Test plan
- [ ] Normal startup/shutdown: verify `backend.pid` is created and removed
- [ ] Force-kill Electron (Task Manager), relaunch, and verify the orphaned backend is cleaned up
- [ ] Verify no errors when PID file doesn't exist or references a dead process
- [ ] Verify normal backend operation is unaffected

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)